### PR TITLE
reduce composer dependencies to needed zf2 modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "zendframework/zend-loader": "~2.0",
         "zendframework/zend-view": "~2.0",
         "zendframework/zend-cache": "~2.0",
+        "zendframework/zend-log": "~2.0",
         "league/commonmark": "~0.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,15 @@
         "ext-curl": "*",
         "michelf/php-markdown": "~1.4",
         "erusev/parsedown-extra": "~0.2",
-        "zendframework/zendframework": "~2.0",
-        "league/commonmark" : "~0.5"
+        "zendframework/zend-stdlib": "~2.0",
+        "zendframework/zend-http": "~2.0",
+        "zendframework/zend-mvc": "~2.0",
+        "zendframework/zend-eventmanager": "~2.0",
+        "zendframework/zend-modulemanager": "~2.0",
+        "zendframework/zend-loader": "~2.0",
+        "zendframework/zend-view": "~2.0",
+        "zendframework/zend-cache": "~2.0",
+        "league/commonmark": "~0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "zendframework/zend-loader": "~2.0",
         "zendframework/zend-view": "~2.0",
         "zendframework/zend-cache": "~2.0",
-        "zendframework/zend-log": "~2.0",
         "league/commonmark": "~0.5"
     },
     "require-dev": {
+        "zendframework/zendframework": "~2.0",
         "phpunit/phpunit": "~4.1"
     },
     "autoload": {


### PR DESCRIPTION
I reduced the dependency map to only needed libraries. This makes your user happy.
Don't force other to require the entire zend framework.