### PR TITLE
Added support for laminas-cache v3 and PHP 8.1

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
         operating-system:
           - "ubuntu-latest"
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "laminas/laminas-modulemanager": "^2.4",
         "laminas/laminas-view": "^2.4",
         "laminas/laminas-cache": "^2.3 || ^3.0",
+        "laminas/laminas-cache-storage-deprecated-factory": "^1.0",
         "laminas/laminas-cache-storage-adapter-memory": "^2.0",
         "laminas/laminas-servicemanager": "^2.4 || ^3.1.1",
         "container-interop/container-interop": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "laminas/laminas-log": "^2.4",
         "laminas/laminas-i18n": "^2.4",
         "laminas/laminas-serializer": "^2.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "laminas/laminas-eventmanager": "^2.4 || ^3.0",
         "laminas/laminas-modulemanager": "^2.4",
         "laminas/laminas-view": "^2.4",
-        "laminas/laminas-cache": "^2.4",
+        "laminas/laminas-cache": "^2.3 || ^3.0",
+        "laminas/laminas-cache-storage-adapter-memory": "^2.0",
         "laminas/laminas-servicemanager": "^2.4 || ^3.1.1",
         "container-interop/container-interop": "^1.1"
     },
@@ -38,7 +39,7 @@
         "phpunit/phpunit": "^9",
         "laminas/laminas-log": "^2.4",
         "laminas/laminas-i18n": "^2.4",
-        "laminas/laminas-console": "^2.4",
+        "laminas/laminas-cli": "^1.0",
         "laminas/laminas-serializer": "^2.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "phpunit/phpunit": "^9",
         "laminas/laminas-log": "^2.4",
         "laminas/laminas-i18n": "^2.4",
-        "laminas/laminas-cli": "^1.0",
         "laminas/laminas-serializer": "^2.4"
     },
     "autoload": {


### PR DESCRIPTION
Prerequisite for PHP 8.1

I removed the development dependency on laminas-console since it was conflicting with this upgrade. I did not replace it with laminas-cli since I could not find any usages for the console package.

The changes should be backwards compatible with laminas-cache v2. All tests passed.

This fixes #15 .